### PR TITLE
fixes #2: JettyWebSocketServer should not use single servlet name for registering servlets

### DIFF
--- a/src/main/java/net/openhft/chronicle/websocket/jetty/JettyWebSocketServer.java
+++ b/src/main/java/net/openhft/chronicle/websocket/jetty/JettyWebSocketServer.java
@@ -25,6 +25,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+import javax.servlet.Servlet;
 import java.io.IOException;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -57,12 +58,15 @@ public class JettyWebSocketServer {
 
     public <T> void addServlet(String path, Function<MarshallableOut, T> outWrapper, BiConsumer<WireIn, T> channel) {
         // Add a websocket to a specific path spec
-        ServletHolder holderEvents = new ServletHolder("ws-events", new JettyServletFactory<T>(outWrapper, channel));
-        context.addServlet(holderEvents, path);
+        addServlet(path, new JettyServletFactory<T>(outWrapper, channel));
     }
 
     public <S, R> void addService(String path, Class<R> responseClass, Function<R, S> serviceFactory) {
-        ServletHolder holderEvents = new ServletHolder("ws-events", new JettyServiceFactory<R, S>(responseClass, serviceFactory));
+        addServlet(path, new JettyServiceFactory<R, S>(responseClass, serviceFactory));
+    }
+
+    private void addServlet(String path, Servlet servlet) {
+        ServletHolder holderEvents = new ServletHolder(path, servlet);
         context.addServlet(holderEvents, path);
     }
 

--- a/src/test/java/net/openhft/chronicle/websocket/jetty/JettyWebSocketServerTest.java
+++ b/src/test/java/net/openhft/chronicle/websocket/jetty/JettyWebSocketServerTest.java
@@ -1,0 +1,83 @@
+package net.openhft.chronicle.websocket.jetty;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.VanillaWireParser;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireParser;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+
+public class JettyWebSocketServerTest {
+    private static final String BAR = "bar";
+    private static final String FOO = "foo";
+
+    @Test
+    public void registersServletsWithDifferentNames() throws IOException, InterruptedException {
+        int port = 19999;
+        JettyWebSocketServer server = new JettyWebSocketServer(port);
+        String foo = "/" + FOO;
+        server.addService(foo + "/*", Service.class, Foo::new);
+        String bar = "/" + BAR;
+        server.addService(bar + "/*", Service.class, Bar::new);
+        server.start();
+
+        {
+            BlockingQueue<CharSequence> q1 = new LinkedBlockingQueue<>();
+            WireParser<MarshallableOut> parser1 = new VanillaWireParser<>((s, v, o) -> q1.add(v.text()));
+            JettyWebSocketClient client1 = new JettyWebSocketClient("ws://localhost:" + port + foo + "/", parser1);
+            client1.writeDocument(w -> w.writeEventName("serve").text("me"));
+            assertEquals(FOO, q1.poll(1, TimeUnit.SECONDS));
+            client1.close();
+        }
+
+        {
+            BlockingQueue<CharSequence> q2 = new LinkedBlockingQueue<>();
+            WireParser<MarshallableOut> parser2 = new VanillaWireParser<>((s, v, o) -> q2.add(v.text()));
+            JettyWebSocketClient client2 = new JettyWebSocketClient("ws://localhost:" + port + bar + "/", parser2);
+            client2.writeDocument(w -> w.writeEventName("serve").text("me"));
+            assertEquals(BAR, q2.poll(1, TimeUnit.SECONDS));
+            client2.close();
+        }
+
+        server.close();
+    }
+
+    private interface Service {
+        void serve(String request);
+    }
+
+    private static final class Foo implements Service {
+        private final Service service;
+
+        private Foo(Service service) {
+            this.service = service;
+        }
+
+        @Override
+        public void serve(String request) {
+            service.serve(FOO);
+        }
+    }
+
+    private static final class Bar implements Service {
+        private final Service service;
+
+        private Bar(Service service) {
+            this.service = service;
+        }
+
+        @Override
+        public void serve(String request) {
+            service.serve(BAR);
+        }
+    }
+}


### PR DESCRIPTION
using path as ServletHolder name